### PR TITLE
Fix link to feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,3 +31,5 @@ theme_color: light
 
 # Build settings
 markdown: kramdown
+gems:
+  - jekyll-feed

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="{{ "/assets/style.css" | prepend: full_base_url }}">
 
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-  <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
+  <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | relative_url }}">
 
   <script async defer src="https://buttons.github.io/buttons.js"></script>
 </head>

--- a/jekyll-athena.gemspec
+++ b/jekyll-athena.gemspec
@@ -14,7 +14,9 @@ Gem::Specification.new do |spec|
     f.match(%r{^(assets|_(includes|layouts|sass)/|(LICENSE|README)((\.(txt|md|markdown)|$)))}i)
   end
 
-  spec.add_development_dependency "jekyll", "~> 3.2"
+  spec.add_runtime_dependency "jekyll-feed", "~> 0.8"
+
+  spec.add_development_dependency "jekyll", "~> 3.3"
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
Added `jekyll-feed` as a dependency to fix a 404 on `feed.xml` 🍃 

Before:

```
❯ htmlproofer _site/*.html
Running ["ImageCheck", "LinkCheck", "ScriptCheck"] on _site/index.html on *.html...

Checking 7 external links...
Ran on 1 file!

- _site/index.html
  *  External link http://localhost:4000/feed.xml failed: 404 No error
htmlproofer 3.3.0 | Error:  HTML-Proofer found 1 failure!
```

After:

```
❯ htmlproofer _site/*.html
Running ["ScriptCheck", "LinkCheck", "ImageCheck"] on _site/index.html on *.html...

Checking 6 external links...
Ran on 1 file!

HTML-Proofer finished successfully.
```
